### PR TITLE
Update dbUtils_notExported.R

### DIFF
--- a/R/dbUtils_notExported.R
+++ b/R/dbUtils_notExported.R
@@ -156,7 +156,7 @@ dbExistsTable <- function (conn, name, table.only = FALSE) {
 ##' @keywords internal
 
 dbConnCheck <- function(conn) {
-  if (inherits(conn, c("PostgreSQLConnection")) | inherits(con_raster, c("PqConnection"))) { {
+  if (inherits(conn, c("PostgreSQLConnection")) | inherits(con_raster, c("PqConnection")))  {
           return(TRUE)
       } else {
         return(stop("'conn' must be a <PostgreSQLConnection> object."))

--- a/R/dbUtils_notExported.R
+++ b/R/dbUtils_notExported.R
@@ -156,7 +156,7 @@ dbExistsTable <- function (conn, name, table.only = FALSE) {
 ##' @keywords internal
 
 dbConnCheck <- function(conn) {
-  if (inherits(conn, c("PostgreSQLConnection"))) {
+  if (inherits(conn, c("PostgreSQLConnection")) | inherits(con_raster, c("PqConnection"))) { {
           return(TRUE)
       } else {
         return(stop("'conn' must be a <PostgreSQLConnection> object."))


### PR DESCRIPTION
accept connections from Rpostgres library. The Rpostgres library allows SSL connections to PostgreSQL instances ,  RPostgreSQL library doesnt. 

https://www.rdocumentation.org/packages/RPostgres/versions/1.1.1