### PR TITLE
changing output info message to only display for non-default output

### DIFF
--- a/R/pgGetRast.R
+++ b/R/pgGetRast.R
@@ -61,7 +61,9 @@ pgGetRast <- function(conn, name, rast = "rast", bands = 1,
                       returnclass = "terra", progress = TRUE) {
   
   ## Message
-  message("Since version 1.5 this function outputs SpatRaster objects by default. Use returnclass = 'raster' to return raster objects.")
+  if (returnclass != "terra") {
+    message("Since version 1.5 this function outputs SpatRaster objects by default. Use returnclass = 'raster' to return raster objects.")
+  }
   
   ## Check connection and PostGIS extension
   dbConnCheck(conn)


### PR DESCRIPTION
Currently `rpostgis` messages on every executing of `pgGetRast`, whether or not a non-default output is specified. The message shows up a lot in the logs of my application and I'd prefer I could silence it without suppressing all messages and warnings from `pgGetRast`.

I suggest to only display the message if a non-default output format is specified. Alternatively, the function could also include a `silence = FALSE` flag to achieve the same outcome.

Please let me know if you think this would work for you.
Thank you for this package and your work to maintain it!